### PR TITLE
Allow Container Type null

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ declare module 'vue-clipboard2' {
         autoSetContainer: boolean,
         appendToBody: boolean
       }
-      $copyText(text: string, container?: object | HTMLElement): Promise<{
+      $copyText(text: string, container?: object | HTMLElement | null): Promise<{
         action: string,
         text: string,
         trigger: String | HTMLElement | HTMLCollection | NodeList,


### PR DESCRIPTION
Since document.querySelector returns `Element | null` it's useful to handle this case here (currently having to do `document.querySelector() || undefined`)